### PR TITLE
User script sandbox changes

### DIFF
--- a/ProjectDescriptionHelpers/Shell.swift
+++ b/ProjectDescriptionHelpers/Shell.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+public enum Shell { }
+
+public extension Shell {
+    /// Run command and capture output
+    /// - Parameter command: Command to be run
+    /// - Returns: Standard output of command or nil if error occured
+    static func capture(_ command: [String]) -> String? {
+        let task = Process()
+        let pipe = Pipe()
+        
+        task.standardOutput = pipe
+        task.standardError = nil
+        task.arguments = ["-c", command.joined(separator: " ")]
+        task.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        task.standardInput = nil
+        task.launch()
+        
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        task.waitUntilExit()
+        
+        if task.terminationStatus != 0 {
+            return nil
+        }
+        
+        return String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+    
+    /// Run command and capture output
+    /// - Parameter command: Command to be run
+    /// - Returns: Standard output of command or nil if error occured
+    static func capture(_ command: String...) -> String? {
+        capture(Array(command))
+    }
+}

--- a/ProjectDescriptionHelpers/Shell.swift
+++ b/ProjectDescriptionHelpers/Shell.swift
@@ -33,4 +33,10 @@ public extension Shell {
     static func capture(_ command: String...) -> String? {
         capture(Array(command))
     }
+    
+    /// Get number of commits in git repo
+    /// - Returns: Number of commits or nil if error occured
+    static func numberOfCommits() -> Int? {
+        capture("git", "rev-list", "HEAD", "--count").flatMap(Int.init)
+    }
 }

--- a/ProjectDescriptionHelpers/TargetScriptExtensions.swift
+++ b/ProjectDescriptionHelpers/TargetScriptExtensions.swift
@@ -28,62 +28,6 @@ public extension TargetScript {
         )
     }
     
-    /// Script that reads number of commits in current git branch
-    /// and sets it to Info.plist in target binary (if any) and in Info.plist file
-    ///
-    /// This command should be run only in git repository, otherwise if will fail getting commits count.
-    static func setBuildNumber() -> TargetScript {
-        .post(
-            script: """
-            set -e
-            
-            pushd "$SRCROOT"
-            
-            echo "Updating build number"
-
-            COMMITS=`git rev-list HEAD --count`
-
-            if [ $? -ne 0 ]; then
-                echo "error: Unable to get commits count, make sure you run project from git repo, or comment out this build phase"
-                exit 1
-            else
-                echo "Number of commits $COMMITS"
-            fi
-
-            echo "Updating Info.plist at ${TARGET_BUILD_DIR}/${INFOPLIST_PATH}"
-
-            # Update build number in created binary's Info.plist
-            /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $COMMITS" "${TARGET_BUILD_DIR}/${INFOPLIST_PATH}"
-
-            if [ $? -ne 0 ]; then
-                # this write can fail as plist might not be present
-                echo "error: Unable to write binary plist"
-            else
-                echo "Binary plist written"
-            fi
-
-            echo "Updating Info.plist at ${INFOPLIST_FILE}"
-
-            # Update build number in original plist so it is consistent
-            /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $COMMITS" "$INFOPLIST_FILE"
-
-            if [ $? -ne 0 ]; then
-                echo "error: Unable to write local plist"
-                exit 3
-            else
-                echo "Local plist written"
-            fi
-
-            echo "Updating build finished"
-            
-            popd
-            """,
-            name: "Set build number",
-            basedOnDependencyAnalysis: false
-        )
-    }
-
-    
     /// Action that tries to run Swiftlint using mint, or directly if mint is not installed
     ///
     /// If Swiftlint cannot be found, then it does nothing

--- a/ProjectDescriptionHelpers/TargetScriptExtensions.swift
+++ b/ProjectDescriptionHelpers/TargetScriptExtensions.swift
@@ -2,9 +2,13 @@ import ProjectDescription
 
 public extension TargetScript {
     /// Action that tries to run Swiftlint using mint, or directly if mint is not installed
-    ///
+    /// 
     /// If Swiftlint cannot be found, then it does nothing
-    static func swiftlint() -> TargetScript {
+    /// - Parameter inputPaths: List of files to be linted, useful when user script sandbox is enabled
+    /// - Returns: Target script to be run
+    static func swiftlint(
+        inputPaths: [FileListGlob] = []
+    ) -> TargetScript {
         .post(
             script: """
             export PATH=/opt/homebrew/bin:${PATH}
@@ -37,6 +41,7 @@ public extension TargetScript {
             echo "SwiftLint not found, not running it"
             """,
             name: "SwiftLint",
+            inputPaths: inputPaths,
             basedOnDependencyAnalysis: false
         )
     }
@@ -44,6 +49,8 @@ public extension TargetScript {
 
 public extension [TargetScript] {
     /// Downloads latest upload dSYM script from Firebase repository and uses it to upload dSYMs
+    /// - Parameter outputDir: Destination where fetched scripts from Crashlytics will be saved
+    /// - Returns: Target scripts to be run
     static func crashlytics(
         outputDir: String = "$SRCROOT/Derived"
     ) -> [TargetScript] {

--- a/ProjectDescriptionHelpers/TargetScriptExtensions.swift
+++ b/ProjectDescriptionHelpers/TargetScriptExtensions.swift
@@ -1,33 +1,6 @@
 import ProjectDescription
 
 public extension TargetScript {
-    /// Downloads latest upload dSYM script from Firebase repository and uses it to upload dSYMs
-    static func crashlytics() -> TargetScript {
-        .post(
-            script: """
-            set -e
-            
-            if [ "$CONFIGURATION" != "Debug" ]; then
-                TMPDIR=`mktemp -d`
-            
-                pushd "$TMPDIR"
-                curl "https://raw.githubusercontent.com/firebase/firebase-ios-sdk/master/Crashlytics/run" > run
-                curl "https://raw.githubusercontent.com/firebase/firebase-ios-sdk/master/Crashlytics/upload-symbols" > upload-symbols
-                chmod +x run upload-symbols
-                ./run
-                popd
-                rm -rf "$TMPDIR"
-            fi
-            """,
-            name: "Crashlytics",
-            inputPaths: [
-                "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}",
-                "$(SRCROOT)/$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)"
-            ],
-            basedOnDependencyAnalysis: false
-        )
-    }
-    
     /// Action that tries to run Swiftlint using mint, or directly if mint is not installed
     ///
     /// If Swiftlint cannot be found, then it does nothing
@@ -35,14 +8,14 @@ public extension TargetScript {
         .post(
             script: """
             export PATH=/opt/homebrew/bin:${PATH}
-
+            
             set -e
-
+            
             if ! [ -f ".swiftlint.yml" ]; then
                 echo "No swiftlint.yml found, not running it"
                 exit 0
             fi
-
+            
             if command -v mint &> /dev/null && grep -iq swiftlint Mintfile; then
                 echo "Mint"
                 pushd "$SRCROOT"
@@ -51,7 +24,7 @@ public extension TargetScript {
                 popd
                 exit 0
             fi
-
+            
             if command -v "swiftlint" &> /dev/null; then
                 echo "Direct"
                 pushd "$SRCROOT"
@@ -60,7 +33,7 @@ public extension TargetScript {
                 popd
                 exit 0
             fi
-
+            
             echo "SwiftLint not found, not running it"
             """,
             name: "SwiftLint",
@@ -69,3 +42,47 @@ public extension TargetScript {
     }
 }
 
+public extension [TargetScript] {
+    /// Downloads latest upload dSYM script from Firebase repository and uses it to upload dSYMs
+    static func crashlytics(
+        outputDir: String = "$SRCROOT/Derived"
+    ) -> [TargetScript] {
+        [
+            .pre(
+                script: """
+                set -e
+                
+                curl "https://raw.githubusercontent.com/firebase/firebase-ios-sdk/master/Crashlytics/run" > \(outputDir)/run
+                curl "https://raw.githubusercontent.com/firebase/firebase-ios-sdk/master/Crashlytics/upload-symbols" > \(outputDir)/upload-symbols
+                chmod +x \(outputDir)/run \(outputDir)/upload-symbols
+                """,
+                name: "Fetch Crashlytics scripts",
+                outputPaths: [
+                    "\(outputDir)/run",
+                    "\(outputDir)/upload-symbols",
+                ]
+            ),
+            .post(
+                script: """
+                set -e
+                
+                "$SCRIPT_INPUT_FILE_0"
+                """,
+                name: "Crashlytics",
+                inputPaths: [
+                    // Input from fetching scripts
+                    "\(outputDir)/run",
+                    "\(outputDir)/upload-symbols",
+                    // Crashlytics files - https://firebase.google.com/docs/crashlytics/get-started?platform=ios#set-up-dsym-uploading
+                    "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}",
+                    "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}",
+                    "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist",
+                    "$(BUILT_PRODUCTS_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/GoogleService-Info.plist",
+                    "$(BUILT_PRODUCTS_DIR)/$(EXECUTABLE_PATH)",
+                    "$(INSTALL_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/GoogleService-Info.plist",
+                ],
+                basedOnDependencyAnalysis: false
+            )
+        ]
+    }
+}

--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ This repository contains [Tuist](https://tuist.io) plugin used throughout our pr
 Example use can be found in our [project template](https://github.com/AckeeCZ/iOS-MVVM-ProjectTemplate).
 
 For more info you can inspect the documentation in code.
+
+> ⚠️ **Keep in mind that at least for now this plugin is more beta, so breaking changes may and probably will occur.**


### PR DESCRIPTION
Enabling user script sandbox required several changes in plugin:
- it is not possible to access _.git_, well it would be but it would require bunch of input files, therefore there is `Shell.numberOfCommits()` that simplifies setting build number to Info.plist when project is generated
- Crashlytics build phase can no longer put its downloaded files where it wants, so it is divided into two scripts, one downloads required scripts (output files also take care of caching it, so it is not run again in incremental builds) the other one uploads dsyms as usual - I also updated its output files according to the latest docs
- Crashlytics build phase is not an extension on `TargetScript` but on `TargetScript` as it produces two scripts
- I also added argument input files to Swiftlint build phase, so it is a bit more useful, but I think it is practically useless with sandbox enabled