### PR TITLE
🐛 map glob pattern to path

### DIFF
--- a/ProjectDescriptionHelpers/TargetScriptExtensions.swift
+++ b/ProjectDescriptionHelpers/TargetScriptExtensions.swift
@@ -41,7 +41,7 @@ public extension TargetScript {
             echo "SwiftLint not found, not running it"
             """,
             name: "SwiftLint",
-            inputPaths: inputPaths,
+            inputPaths: inputPaths.map(\.glob),
             basedOnDependencyAnalysis: false
         )
     }


### PR DESCRIPTION
I had an issue to build plugin with `swiftlint` with specified `inputpath` not being `[Path]`
```
/.tuist/Cache/Plugins/7f778916b5141efe661ed06eb29384aa/Repository/ProjectDescriptionHelpers/TargetScriptExtensions.swift:44:25: error: cannot convert value of type '[FileListGlob]' to expected argument type '[Path]'
            inputPaths: inputPaths,
```