### PR TITLE
Fix configuration settings inheritance

### DIFF
--- a/ProjectDescriptionHelpers/Configuration.swift
+++ b/ProjectDescriptionHelpers/Configuration.swift
@@ -9,7 +9,7 @@ public extension Configuration {
         let rawValue = ProjectDescription.Environment.configuration.getString(default: "debug").lowercased()
         let settings: SettingsDictionary = [
             "SWIFT_ACTIVE_COMPILATION_CONDITIONS": [
-                "$(inherited)",
+                .string("$(inherited)"),
                 .string(rawValue.uppercased()),
             ],
         ]

--- a/ProjectDescriptionHelpers/Configuration.swift
+++ b/ProjectDescriptionHelpers/Configuration.swift
@@ -8,10 +8,7 @@ public extension Configuration {
     static var current: Self {
         let rawValue = ProjectDescription.Environment.configuration.getString(default: "debug").lowercased()
         let settings: SettingsDictionary = [
-            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": [
-                .string("$(inherited)"),
-                .string(rawValue.uppercased()),
-            ],
+            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": .string("$(inherited) \(rawValue.uppercased())"),
         ]
         
         switch rawValue {

--- a/ProjectDescriptionHelpers/Configuration.swift
+++ b/ProjectDescriptionHelpers/Configuration.swift
@@ -8,7 +8,10 @@ public extension Configuration {
     static var current: Self {
         let rawValue = ProjectDescription.Environment.configuration.getString(default: "debug").lowercased()
         let settings: SettingsDictionary = [
-            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": .string(rawValue.uppercased()),
+            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": [
+                "$(inherited)",
+                .string(rawValue.uppercased()),
+            ],
         ]
         
         switch rawValue {


### PR DESCRIPTION
As we were missing `$(inherited)` in build settings for our custom configurations, we could have been missing `SWIFT_PACKAGE` compilation condition in Tuist Dependencies which could break getting resources inside an SPM package.